### PR TITLE
Add prettier test assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 heck = "0.3.3"
 itertools = "0.10.1"
+pretty_assertions = "0.7.2"


### PR DESCRIPTION
This PR adds support for running stringified tokens through `rustfmt` + nice diffs with `pretty_assertions`.