### PR TITLE
Cleanup, take 3

### DIFF
--- a/lib/benches/iai.rs
+++ b/lib/benches/iai.rs
@@ -1,13 +1,12 @@
 use iai::black_box;
-use discord_typed_interactions_lib::structify;
-
+use discord_typed_interactions_lib::typify_driver;
 
 fn no_subcommands() {
-    structify(black_box(include_str!("../../test-harness/schema/no_subcommands.json")));
+    typify_driver(black_box(include_str!("../../test-harness/schema/no_subcommands.json")));
 }
 
 fn ctf() {
-    structify(black_box(include_str!("../../test-harness/schema/ctf.json")));
+    typify_driver(black_box(include_str!("../../test-harness/schema/ctf.json")));
 }
 
 iai::main!(no_subcommands, ctf);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -59,7 +59,7 @@ fn parse_type<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<Type>
     impl<'de> Visitor<'de> for TypeVisitor {
         type Value = Option<Type>;
         fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            f.write_str("3..=9")
+            f.write_str("1..=9")
         }
         // https://discord.com/developers/docs/interactions/slash-commands#data-models-and-types
         fn visit_u64<E: Error>(self, v: u64) -> Result<Self::Value, E> {
@@ -67,6 +67,7 @@ fn parse_type<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<Type>
                 4 => Ok(Some(Type::U64)),
                 5 => Ok(Some(Type::Bool)),
                 3 | 6..=9 => Ok(Some(Type::String)),
+                1 | 2 => Ok(None),
                 _ => Err(E::invalid_value(Unexpected::Unsigned(v), &self)),
             }
         }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -226,7 +226,6 @@ pub fn typify_driver(input: &str) -> TokenStream {
     let root_module_snake = modules.keys().map(|x| &x.snake);
     let root_module_camel = modules.keys().map(|x| &x.camel);
     let (options_type_tokens, options_enum_tokens) = if root.iter().any(|x| x.r#type.is_none()) {
-        // 0 is not a valid type which means its the default/the container of root properties
         let x = root.first().expect("root to be nonempty");
         let x_ident = &x.name.snake;
         (quote! { crate::#root_name::#x_ident::Options }, quote! {})

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,13 +1,11 @@
-extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use syn::LitStr;
-use syn::{parse_macro_input};
+use syn::parse_macro_input;
 
 #[proc_macro]
-pub fn generate_structs(input: TokenStream) -> TokenStream {
-
-    discord_typed_interactions_lib::structify(
+pub fn typify(input: TokenStream) -> TokenStream {
+    discord_typed_interactions_lib::typify_driver(
         &std::fs::read_to_string(parse_macro_input!(input as LitStr).value())
             .expect("provided file should be readable"),
     )

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [workspace]
 
 [dependencies]
-discord_typed_interactions = { path = "../wrapper" }
+discord_typed_interactions = { path = "../wrapper", features = ["macro"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 

--- a/test-harness/src/ctf.rs
+++ b/test-harness/src/ctf.rs
@@ -1,7 +1,7 @@
-use discord_typed_interactions::generate_structs;
+use discord_typed_interactions::typify;
 use serde_json::json;
 
-generate_structs!("./schema/ctf.json");
+typify!("./schema/ctf.json");
 
 fn main() {
     let play = json!({

--- a/test-harness/src/no_subcommands.rs
+++ b/test-harness/src/no_subcommands.rs
@@ -1,7 +1,7 @@
-use discord_typed_interactions::generate_structs;
+use discord_typed_interactions::typify;
 use serde_json::json;
 
-generate_structs!("./schema/no_subcommands.json");
+typify!("./schema/no_subcommands.json");
 
 fn main() {
     let test = json!({

--- a/wrapper/Cargo.toml
+++ b/wrapper/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 discord_typed_interactions_lib = { path = "../lib" }
-discord_typed_interactions_proc_macro = { path = "../macro" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
+discord_typed_interactions_proc_macro = { path = "../macro", optional = true }
+
+[features]
+macro = ["discord_typed_interactions_proc_macro"]

--- a/wrapper/src/lib.rs
+++ b/wrapper/src/lib.rs
@@ -1,2 +1,40 @@
-pub use discord_typed_interactions_proc_macro::generate_structs;
-pub use serde;
+#[cfg(feature = "macro")]
+pub use discord_typed_interactions_proc_macro::typify;
+
+#[cfg(not(feature = "macro"))]
+pub mod export {
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+    use std::io::Write;
+    use discord_typed_interactions_lib::typify_driver;
+
+    fn fmt(input: &str) -> Option<String> {
+        let mut proc = Command::new("rustfmt")
+            .arg("--emit=stdout")
+            .arg("--edition=2018")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+        let stdin = proc.stdin.as_mut()?;
+        stdin.write_all(input.as_bytes()).ok()?;
+        let output = proc.wait_with_output().ok()?;
+
+        if output.status.success() {
+            String::from_utf8(output.stdout).ok()
+        } else {
+            None
+        }
+    }
+
+    // TODO: make a config struct, bikeshed name, etc.
+    pub fn todo(src: impl AsRef<Path>, dst: impl AsRef<Path>) {
+        let schema_contents = std::fs::read_to_string(src).unwrap();
+        let rust_source = typify_driver(&schema_contents).to_string();
+        let formatted_source = fmt(&rust_source).unwrap_or(rust_source);
+        std::fs::write(dst, formatted_source).unwrap();
+    }
+}
+#[cfg(not(feature = "macro"))]
+pub use export::*;


### PR DESCRIPTION
- in the `wrapper` crate, expose `typify!` as a proc macro and `todo()` for manual code generation (name needs to be bikeshed + add config options)
- golf down some `quote!` invocations
- generate cased names upfront while parsing `CommandOption` with custom `serde` impl
- reject invalid type numbers while parsing `CommandOption`