### PR TITLE
Optimize extract modules (numbers go down)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '**' ]
   pull_request:
     branches: [ master ]
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -223,8 +223,8 @@ pub fn typify_driver(input: &str) -> TokenStream {
     let options_enum_tokens = DeferredConditional(has_options, || quote! {}, || {
         let root_enum_snake = root.iter().map(|x| x.name.snake());
         let root_enum_camel = root.iter().map(|x| x.name.camel());
-        let root_module_snake = modules.iter().map(|(a,_)| a).map(|x| x.snake());
-        let root_module_camel = modules.iter().map(|(a,_)| a).map(|x| x.camel());
+        let root_module_snake = modules.iter().map(|(x, _)| x.snake());
+        let root_module_camel = modules.iter().map(|(x, _)| x.camel());
         // this deserializer relies on the assumption that there can only be a single subcommand active at a time
         quote! {
             #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -299,6 +299,6 @@ mod tests {
     #[test]
     fn extracts_modules() {
         let cmd_option = serde_json::from_str(include_str!("../../test-harness/schema/multiple_subgroups.json")).unwrap();
-        let (root, submodules) = extract_modules(&cmd_option);
+        let (_root, _submodules) = extract_modules(&cmd_option);
     }
 }

--- a/test-harness/schema/multiple_subgroups.json
+++ b/test-harness/schema/multiple_subgroups.json
@@ -1,0 +1,72 @@
+{
+  "name": "multiple_sub_groups",
+  "description": "placeholder",
+  "options": [
+    {
+      "type": 2,
+      "name": "group1",
+      "description": "placeholder",
+      "options": [
+        {
+          "type": 1,
+          "name": "group1_left",
+          "description": "placeholder",
+          "options": [
+            {
+              "type": 9,
+              "name": "name",
+              "description": "placeholder",
+              "required": true
+            }
+          ]
+        },
+        {
+          "type": 1,
+          "name": "group1_right",
+          "description": "placeholder",
+          "options": [
+            {
+              "type": 9,
+              "name": "name",
+              "description": "placeholder",
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": 2,
+      "name": "group2",
+      "description": "placeholder",
+      "options": [
+        {
+          "type": 1,
+          "name": "group2_left",
+          "description": "placeholder",
+          "options": [
+            {
+              "type": 9,
+              "name": "name",
+              "description": "placeholder",
+              "required": true
+            }
+          ]
+        },
+        {
+          "type": 1,
+          "name": "group2_right",
+          "description": "placeholder",
+          "options": [
+            {
+              "type": 9,
+              "name": "name",
+              "description": "placeholder",
+              "required": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
```text
no_subcommands
  Instructions:              300905 (-0.590041%)
  L1 Accesses:               436834 (-0.557499%)
  L2 Accesses:                  775 (-4.791155%)
  RAM Accesses:                1687 (-2.990224%)
  Estimated Cycles:          499754 (-0.885331%)

ctf
  Instructions:             1434649 (-0.182707%)
  L1 Accesses:              2112420 (-0.178669%)
  L2 Accesses:                 4784 (+4.090513%)
  RAM Accesses:                3971 (-2.528228%)
  Estimated Cycles:         2275325 (-0.282500%)
```
L2 accesses went up but RAM went down so I think that's a net win here